### PR TITLE
Add support for .bmp and .png images in artwork uploads

### DIFF
--- a/config/sql/se/Artworks.sql
+++ b/config/sql/se/Artworks.sql
@@ -13,6 +13,7 @@ CREATE TABLE `Artworks` (
   `CopyrightPageUrl` varchar(255) NULL,
   `ArtworkPageUrl` varchar(255) NULL,
   `EbookWwwFilesystemPath` varchar(255) NULL,
+  `MimeType` varchar(64) NOT NULL,
   PRIMARY KEY (`ArtworkId`),
   KEY `index1` (`Status`),
   KEY `index2` (`UrlName`)

--- a/lib/ArtworkMimeType.php
+++ b/lib/ArtworkMimeType.php
@@ -1,0 +1,52 @@
+<?
+
+enum ArtworkMimeType: string{
+	case JPG = "image/jpeg";
+	case BMP = "image/bmp";
+	case PNG = "image/png";
+
+	public function GetFileExtension(): string{
+		return match ($this){
+			self::JPG => ".jpg",
+			self::BMP => ".bmp",
+			self::PNG => ".png",
+		};
+	}
+
+	/**
+	 * @return resource
+	 * @throws \Safe\Exceptions\ImageException
+	 */
+	public function ImageCreateFromMimeType(string $filename){
+		return match ($this){
+			self::JPG => \Safe\imagecreatefromjpeg($filename),
+			self::BMP => \Safe\imagecreatefrombmp($filename),
+			self::PNG => \Safe\imagecreatefrompng($filename),
+		};
+	}
+
+	public static function FromUploadedFile(array $uploadedFile): null|ArtworkMimeType{
+		$filePath = $uploadedFile['tmp_name'];
+		$fileInfo = finfo_open(FILEINFO_MIME_TYPE);
+
+		$mimeType = finfo_file($fileInfo, $filePath);
+		$mimeType = match ($mimeType){
+			"image/x-ms-bmp", "image/x-bmp" => "image/bmp",
+			default => $mimeType,
+		};
+
+		finfo_close($fileInfo);
+
+		if(!$mimeType){
+			return null;
+		}
+
+		return ArtworkMimeType::tryFrom($mimeType);
+	}
+
+	public static function Values(): array{
+		return array_map(function (ArtworkMimeType $case){
+			return $case->value;
+		}, ArtworkMimeType::cases());
+	}
+}

--- a/scripts/upsert-to-cover-art-database
+++ b/scripts/upsert-to-cover-art-database
@@ -113,6 +113,7 @@ if($artwork === null){
 	$artwork->Created = new DateTime();
 	$artwork->Status = COVER_ARTWORK_STATUS_IN_USE;
 	$artwork->EbookWwwFilesystemPath = $ebookWwwFilesystemPath;
+	$artwork->MimeType = ArtworkMimeType::JPG;
 
 	$coverSourceFile = tempnam($workDir, 'cover.source.');
 	// Search for JPEG, PNG, and TIFF source files, in that order.

--- a/www/artworks/new.php
+++ b/www/artworks/new.php
@@ -195,7 +195,7 @@ if($exception){
 							name="color-upload"
 							id="input-color-upload"
 							required="required"
-							accept="image/jpeg"
+							accept="<?= implode(",", ArtworkMimeType::Values()) ?>"
 						/>
 					</label>
 					<button>Submit</button>

--- a/www/artworks/post.php
+++ b/www/artworks/post.php
@@ -8,7 +8,7 @@ function post_max_size_bytes(): int{
 	$unit = substr($post_max_size, -1);
 	$size = (int) substr($post_max_size, 0, -1);
 
-	return match ($unit) {
+	return match ($unit){
 		'g', 'G' => $size * 1024 * 1024 * 1024,
 		'm', 'M' => $size * 1024 * 1024,
 		'k', 'K' => $size * 1024,
@@ -48,6 +48,7 @@ try{
 	$artwork->CopyrightPageUrl = HttpInput::Str(POST, 'pd-proof-copyright-page-url', false);
 	$artwork->ArtworkPageUrl = HttpInput::Str(POST, 'pd-proof-artwork-page-url', false);
 	$artwork->MuseumUrl = HttpInput::Str(POST, 'pd-proof-museum-url', false);
+	$artwork->MimeType = ArtworkMimeType::FromUploadedFile($_FILES['color-upload']);
 
 	$expectCaptcha = HttpInput::Str(SESSION, 'captcha', false);
 	$actualCaptcha = HttpInput::Str(POST, 'captcha', false);


### PR DESCRIPTION
@colagrosso Here's the support for additional image formats as discussed in the main PR. I've left out TIFF for now because PHP's GD library doesn't support it, so we'll have to fall back to `exec('convert')` or similar if we want to implement it in the future.

The `ArtworkMimeType` enum is really just a place to group together logic relating to handling different file types. Adding support for additional types in the future should only require changing this file. It also converts between the mime types used by php/gd and php/fileinfo (that's the `image/x-ms-bmp` stuff).

I've also switched to using php/fileinfo for detecting image types, as opposed to `getimagesize`. As far as I can tell this seems to be the recommended approach nowadays (see the caution note here https://www.php.net/manual/en/function.getimagesize.php).